### PR TITLE
update FIM vizualization module and added google colab link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ fm.DownloadHUC8(HUC)    #Like this it contains multiples functionality.
 ```
 Then there are a lot of different modules, call it to work. For reference to run, [Here (docs/code_usage.ipynb)](./docs/code_usage.ipynb) is the sample usuage of this code and different functionality. 
 
+For quick usage: Use google colab. Here is **fimserve  in google colab**: [![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1rwyoHmZJzCdvfn9pK-4csuXg7SVTeG-q?usp=sharing)
+
 
 **Different HUC8 IDs, USGS gauge stations and flowline informations that might be require to further understand/running this framework can be found in this <a href="https://ualabama.maps.arcgis.com/apps/instant/basic/index.html?appid=88789b151b50430d8e840d573225b36b" target="_blank">ArcGIS Instant App</a>.** 
 

--- a/src/fimserve/vizualizationFIM.py
+++ b/src/fimserve/vizualizationFIM.py
@@ -9,6 +9,19 @@ from ipywidgets import HTML
 from .datadownload import setup_directories
 
 
+def InitializeGEE(projectID=None):
+    import ee
+
+    try:
+        ee.Authenticate(force=True)
+        if projectID:
+            ee.Initialize(project=projectID)
+        else:
+            ee.Initialize()
+    except Exception as e:
+        print(f"Error initializing GEE: {e}")
+
+
 def FIMVizualizer(raster_path, catchment_gpkg, zoom_level):
     with rasterio.open(raster_path) as src:
         data = src.read(1)
@@ -72,7 +85,7 @@ def FIMVizualizer(raster_path, catchment_gpkg, zoom_level):
     return Map
 
 
-def vizualizeFIM(inundation_raster, huc, zoom_level):
+def vizualizeFIM(inundation_raster, huc, zoom_level, projectID=None):
     code_dir, data_dir, output_dir = setup_directories()
     HUCBoundary = os.path.join(
         output_dir,
@@ -82,4 +95,5 @@ def vizualizeFIM(inundation_raster, huc, zoom_level):
         "0",
         "gw_catchments_reaches_filtered_addedAttributes_0.gpkg",
     )
+    InitializeGEE(projectID)
     return FIMVizualizer(inundation_raster, HUCBoundary, zoom_level)


### PR DESCRIPTION
Now during FIM visualization, if the user gets some permission error, the user can pass the existing project ID (or create one) as one of the parameters. 

fm.vizualizeFIM(inundation_raster, huc, MapZoom, projectID='supathdh').